### PR TITLE
Update MemPoolHeap.h functions to use [[maybe_unused]]

### DIFF
--- a/MempoolHeap/src/MemPoolHeap.h
+++ b/MempoolHeap/src/MemPoolHeap.h
@@ -317,7 +317,7 @@ public:
   // this constructor is private and will only be called by the other constructor to create a temporary object
   // to figure out size/alignment
   template <typename U, typename ... Args>
-  SharedPointerAllocator(const AllocatorT<U> &allocator, Args&&... args)
+  SharedPointerAllocator(const AllocatorT<U> &allocator, [[maybe_unused]] Args&&... args)
     : state(std::allocate_shared<StateT>(AllocatorT<StateT>(allocator), 1, allocator))
   {
     
@@ -671,8 +671,8 @@ public:
 };
 
 template <class T, class U>
-bool operator==(Passthrough_Allocator<T> const& x, 
-                Passthrough_Allocator<U> const& y) noexcept
+bool operator==([[maybe_unused]] Passthrough_Allocator<T> const& x, 
+                [[maybe_unused]] Passthrough_Allocator<U> const& y) noexcept
 {
   return true;
 }


### PR DESCRIPTION
When compiling in clang with strict warnings in place (wall, wextra) MemPoolHeap.h throws warnings about unused variables. Utilizing the [[maybe_unused]] attribute to indicate that these function inputs are unused without modifying surrounding code or commenting out the function input variables.

Closes #3 